### PR TITLE
chore: add branch protection docs and helper

### DIFF
--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,0 +1,41 @@
+Branch Protection — Anleitung
+
+Ziel
+----
+Diese Anleitung erklärt, wie du Branch Protection (Schutzregel) für den Branch `main` aktivierst.
+
+Option A — Per GUI (empfohlen, sofort ausführbar)
+1. Öffne das Repository auf GitHub.
+2. Gehe zu `Settings` → `Branches` → `Add rule`.
+3. Setze `Branch name pattern` auf `main`.
+4. Aktiviere:
+   - "Require pull request reviews before merging" (setze mindestens 1 Review required)
+   - "Require status checks to pass before merging" und wähle `CI` aus
+   - Optional: "Include administrators" (erzwungen für Admins)
+5. Speichern.
+
+Option B — Per CLI / API (nützlich zur Automatisierung)
+Hinweis: Für private Repositories kann GitHub das Setzen per API einschränken (geht nur bei bestimmten Account/Plan-Einstellungen). Wenn die API fehlschlägt, nutze die GUI (Option A).
+
+PowerShell (gh CLI) — Beispiel für lokale Ausführung:
+
+```powershell
+# Voraussetzungen:
+# - gh (GitHub CLI) ist installiert und eingeloggt
+# - Repo ist öffentlich ODER dein Account/Org unterstützt branch-protection via API
+
+$body = @{
+  required_status_checks = @{ strict = $true; contexts = @("CI") }
+  enforce_admins = $true
+  required_pull_request_reviews = @{ dismiss_stale_reviews = $true; require_code_owner_reviews = $false; required_approving_review_count = 1 }
+} | ConvertTo-Json -Depth 5
+
+gh api --method PUT /repos/hentschel873-cyber/Python/branches/main/protection -f "$body"
+```
+
+Wenn die API auf einen 403/Planfehler läuft, folge Option A oder ändere die Repository-Sichtbarkeit.
+
+Weiteres
+------
+- Wenn du möchtest, kann ich dieses Skript in das Repo einfügen und einen PR öffnen (bereitgestellt in `scripts/enable-branch-protection.ps1`).
+- Das Skript ist nur ein Convenience-Wrapper; die eigentliche Berechtigung/Plan muss auf deiner Seite passen.

--- a/scripts/enable-branch-protection.ps1
+++ b/scripts/enable-branch-protection.ps1
@@ -1,0 +1,31 @@
+<#
+PowerShell helper to attempt to enable branch protection for `main`.
+
+Usage:
+  - Ensure `gh` CLI is installed and you are logged in (`gh auth login`).
+  - Run this script from PowerShell as a user with sufficient rights.
+
+Note: GitHub may return HTTP 403 if the repo is private and the plan doesn't permit programmatic branch protection.
+#>
+
+param()
+
+$body = @{
+    required_status_checks = @{ strict = $true; contexts = @("CI") }
+    enforce_admins = $true
+    required_pull_request_reviews = @{ dismiss_stale_reviews = $true; require_code_owner_reviews = $false; required_approving_review_count = 1 }
+} | ConvertTo-Json -Depth 5
+
+Write-Host "Attempting to set branch protection on 'main'..."
+
+# Run the gh api call
+$cmd = "gh api --method PUT /repos/hentschel873-cyber/Python/branches/main/protection -f '$body'"
+Write-Host $cmd
+
+Invoke-Expression $cmd
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to set branch protection. Check repository visibility / plan or run the GUI steps in docs/BRANCH_PROTECTION.md"
+} else {
+    Write-Host "Branch protection API call completed. Verify on GitHub Settings → Branches."
+}


### PR DESCRIPTION
Add documentation and a PowerShell helper script to enable branch protection for 'main'. The API may require repo visibility/plan changes; instructions included.