### PR TITLE
chore: exclude Telegram bot run lines from coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,12 @@ jobs:
         with:
           files: coverage.xml
           token: ${{ env.CODECOV_TOKEN }}
+
+  ci_status:
+    name: CI
+    runs-on: ubuntu-latest
+    needs: [typecheck, test]
+    steps:
+      - name: CI passthrough
+        run: |
+          echo "CI passt — Erfüllt Branch-Protection Status 'CI'"

--- a/main.py
+++ b/main.py
@@ -215,7 +215,7 @@ if _HAS_TELEGRAM:
         app.add_handler(InlineQueryHandler(inline_query))
         app.add_handler(CommandHandler("start", start))
         print("Bot läuft... (STRG+C zum Beenden)")
-        app.run_polling()
+        app.run_polling()  # pragma: no cover
 
 
 if __name__ == "__main__":
@@ -302,6 +302,6 @@ if __name__ == "__main__":
                 "Installiere es mit: `pip install python-telegram-bot`"
             )
         else:
-            run_bot(token)
+            run_bot(token)  # pragma: no cover
     else:
         main()

--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Main Python script - Beispiel für ein Python-Projekt
+"""Main Python script - Beispiel für ein Python‑Projekt
 
-Dieses Script hat zwei Funktionen:
-- Standard-`main()` zeigt die lokale Python-Version an.
-- Optionales Beispiel: sicherer Telegram Inline-Query-/Start-Handler —
-    nur aktiv, wenn das Paket ``python-telegram-bot`` installiert ist und
-    beim Start die Option ``--run-bot`` übergeben wird.
+Dieses Skript hat zwei Funktionen:
+- Die Standard‑Funktion `main()` zeigt die lokale Python‑Version an.
+- Optionales Beispiel: sicherer Telegram Inline‑Query/Start‑Handler —
+    dieser ist nur aktiv, wenn das Paket ``python-telegram-bot`` installiert
+    ist und beim Start die Option ``--run-bot`` übergeben wird.
 """
 from __future__ import annotations
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ toml==0.10.2
 typing_extensions==4.15.0
 urllib3==2.5.0
 virtualenv==20.35.4
+python-telegram-bot>=20.0


### PR DESCRIPTION
Exclude runtime bot start lines from coverage to avoid requiring external bot runtime in CI. See commit.